### PR TITLE
pin to alpine3.13 

### DIFF
--- a/services/workshop/Dockerfile
+++ b/services/workshop/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM python:3.8-alpine as build
+FROM python:3.8-alpine3.13 as build
 # Not using alpine based on suggestion
 # https://pythonspeed.com/articles/alpine-docker-python/
 


### PR DESCRIPTION
until https://gitlab.alpinelinux.org/alpine/aports/-/issues/12763 is resolved, `workshop/build-image.sh` fails with:

```
 > [build 3/7] RUN apk add --update --no-cache --virtual .build-deps         python3-dev openssl-dev         libffi-dev gcc py3-pip         python3-dev         libressl-dev         musl-dev         libffi-dev:
#9 0.268 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#9 0.522 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#9 0.799 (1/17) Installing python3-dev (3.9.5-r1)
#9 1.372 (2/17) Installing linux-headers (5.10.41-r0)
#9 1.472 (3/17) Installing libffi-dev (3.3-r2)
#9 1.490 (4/17) Installing binutils (2.35.2-r2)
#9 1.582 (5/17) Installing libatomic (10.3.1_git20210424-r2)
#9 1.603 (6/17) Installing libgphobos (10.3.1_git20210424-r2)
#9 1.672 (7/17) Installing gmp (6.2.1-r0)
#9 1.695 (8/17) Installing isl22 (0.22-r0)
#9 1.730 (9/17) Installing mpfr4 (4.1.0-r0)
#9 1.799 (10/17) Installing mpc1 (1.2.1-r0)
#9 1.814 (11/17) Installing gcc (10.3.1_git20210424-r2)
#9 2.642 (12/17) Installing libressl3.3-libcrypto (3.3.3-r0)
#9 2.680 (13/17) Installing libressl3.3-libssl (3.3.3-r0)
#9 2.700 (14/17) Installing libressl3.3-libtls (3.3.3-r0)
#9 2.717 ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20 owned by libretls-3.3.3-r0.
#9 2.717 ERROR: libressl3.3-libtls-3.3.3-r0: trying to overwrite usr/lib/libtls.so.20.0.3 owned by libretls-3.3.3-r0.
#9 2.735 (15/17) Installing libressl-dev (3.3.3-r0)
#9 3.058 (16/17) Installing musl-dev (1.2.2-r3)
#9 3.154 (17/17) Installing .build-deps (20210720.162834)
#9 3.155 Executing busybox-1.33.1-r2.trigger
#9 3.163 1 error; 595 MiB in 104 packages
------
executor failed running [/bin/sh -c apk add --update --no-cache --virtual .build-deps         python3-dev openssl-dev         libffi-dev gcc py3-pip         python3-dev         libressl-dev         musl-dev         libffi-dev]: exit code: 1
```