### PR TITLE
Dynamic Port Setting for Identity and Community Apps

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - DB_PASSWORD=crapisecretpassword
       - DB_HOST=postgresdb
       - DB_PORT=5432
+      - SERVER_PORT=8087
       - MONGO_DB_HOST=mongodb
       - MONGO_DB_PORT=27017
       - MONGO_DB_USER=admin

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - DB_PASSWORD=crapisecretpassword
       - DB_HOST=postgresdb
       - DB_PORT=5432
+      - SERVER_PORT=8080
       - BLOCK_SHELL_INJECTION=false
       - JWT_SECRET=crapi
       - MAILHOG_HOST=mailhog

--- a/services/community/api/server.go
+++ b/services/community/api/server.go
@@ -49,6 +49,6 @@ func Run() {
 
 	server.Router = route.InitializeRoutes()
 
-	route.Run(":8087")
+	route.Run(":"+os.Getenv("SERVER_PORT"))
 
 }

--- a/services/identity/src/main/resources/application.properties
+++ b/services/identity/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.password=${DB_PASSWORD}
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
+# Server
+server.port=${SERVER_PORT}
+
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto=update
 


### PR DESCRIPTION
Identity app is a spring app and it works on default port 8080. By this change, we can define a custom number through the docker-compose file.