### PR TITLE
Added Heap memory limit for crapi-identity java application

### DIFF
--- a/services/identity/Dockerfile
+++ b/services/identity/Dockerfile
@@ -28,4 +28,6 @@ RUN mkdir /app
 COPY --from=javabuild /app/target/user-microservices-1.0-SNAPSHOT.jar /app/user-microservices-1.0-SNAPSHOT.jar
 EXPOSE 8080
 
+ENV JAVA_TOOL_OPTIONS "-Xmx128m"
+
 CMD java -jar /app/user-microservices-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Fixes crapi-identity application crashing because of out-of-memory error.