### PR TITLE
Increased memory limit for crapi-identity container

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       resources:
         limits:
           cpus: '0.8'
-          memory: 256M
+          memory: 384M
 
   crapi-community:
     container_name: crapi-community


### PR DESCRIPTION
## Description
Pull request to fix #56 . This will make it more likely for docker-compose to work to start the crAPI services.

Initially I fixed this with 512M, but since the original limit was 256M I changed it to 384M just to keep it lighter weight.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested the service locally. 

Testing involved 2 different machines, one local VM and one VM in AWS. 
Steps taken to test:
* Cloned the repo
* git checkout main
* VERSION=latest docker-compose -f deploy/docker/docker-compose.yml --compatibility up -d
* Verified error happened where crapi-identity started, then crashed leaving the container unhealthy
* Made the change
* To clear the containers, ran: VERSION=latest docker-compose -f deploy/docker/docker-compose.yml --compatibility down
* Ran the up version of the docker-compose command again
* Verified it worked.

Repeated the docker-compose down then docker-compose up commands a few times to on each machine to ensure it wasn't a fluke.

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged
- [X] I have documented any changes if required in the [docs](docs). 
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
