### PR TITLE
Update Vagrant to use prebuilt images and fix db versions

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -157,7 +157,7 @@ services:
 
   postgresdb:
     container_name: postgresdb
-    image: 'postgres'
+    image: 'postgres:14'
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: crapisecretpassword
@@ -176,10 +176,10 @@ services:
         limits:
           cpus: '0.3'
           memory: 128M
-  
+
   mongodb:
     container_name: mongodb
-    image: 'mongo'
+    image: 'mongo:4.4'
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: crapisecretpassword
@@ -206,7 +206,7 @@ services:
     environment:
       MH_MONGO_URI: admin:crapisecretpassword@mongodb:27017
       MH_STORAGE: mongodb
-    ports: 
+    ports:
     #  - "127.0.0.1:1025:1025" # smtp server
       - "127.0.0.1:8025:8025" # Mail ui
     healthcheck:

--- a/deploy/vagrant/provisioner.sh
+++ b/deploy/vagrant/provisioner.sh
@@ -33,10 +33,10 @@ curl -sL https://github.com/docker/compose/releases/download/v2.5.0/docker-compo
 chmod +x /usr/local/bin/docker-compose
 ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 
-# Build crAPI
-"$MOUNT_DIR/deploy/docker/build-all.sh"
+# Build crAPI 
+# "$MOUNT_DIR/deploy/docker/build-all.sh"
 
-# Install crAPI
+# Install crAPI using prebuilt images
 mkdir /opt/crapi
 
 cp "$MOUNT_DIR/deploy/docker/docker-compose.yml" /opt/crapi \


### PR DESCRIPTION
Update Vagrant to use prebuilt images
Fix DB versions

## Description
Changing vagrant deployment option to use prebuilt images from our CD pipeline.
Fix DB versions to prevent 132 exit codes on old cpus

### Testing
Vagrant local tests

### Documentation
N/A

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required in the [docs](docs). 

