### PR TITLE
Incorrect Login Credentials Unhandled Exception

### DIFF
--- a/services/identity/src/main/java/com/crapi/controller/AuthController.java
+++ b/services/identity/src/main/java/com/crapi/controller/AuthController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.io.UnsupportedEncodingException;
+import org.springframework.security.authentication.BadCredentialsException;
 
 
 
@@ -48,11 +49,19 @@ public class AuthController {
      */
     @PostMapping("/login")
     public ResponseEntity<JwtResponse> authenticateUser(@Valid @RequestBody LoginForm loginForm) throws UnsupportedEncodingException {
-        JwtResponse jwtToken = userService.authenticateUserLogin(loginForm);
-        if (jwtToken!=null && jwtToken.getToken()!=null) {
-            return ResponseEntity.status(HttpStatus.OK).body(jwtToken);
-        }else {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(jwtToken);
+        try {        
+
+            JwtResponse jwtToken = userService.authenticateUserLogin(loginForm);
+
+            if(jwtToken.getToken() != null) {
+                return ResponseEntity.status(HttpStatus.OK).body(jwtToken);
+            }
+            else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(jwtToken);
+            }
+
+        } catch (BadCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new JwtResponse("",UserMessage.INVALID_CREDENTIALS));
         }
     }
 
@@ -148,6 +157,6 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(jwt);
     }
 
-    
+
 
 }

--- a/services/identity/src/main/java/com/crapi/service/Impl/UserDetailsServiceImpl.java
+++ b/services/identity/src/main/java/com/crapi/service/Impl/UserDetailsServiceImpl.java
@@ -45,8 +45,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             System.out.println(user);
             return UserPrinciple.build(user);
         }catch (Exception e){
-            e.printStackTrace();
-            return null;
+            throw new UsernameNotFoundException("User does not exist with Email :" +email);
         }
 
 

--- a/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
+++ b/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
@@ -40,7 +40,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
+import org.springframework.security.authentication.BadCredentialsException;
 import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 import java.io.UnsupportedEncodingException;
@@ -93,7 +93,7 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public JwtResponse authenticateUserLogin(LoginForm loginForm) throws UnsupportedEncodingException {
+    public JwtResponse authenticateUserLogin(LoginForm loginForm) throws UnsupportedEncodingException, BadCredentialsException {
         JwtResponse jwtResponse = new JwtResponse();
         Authentication authentication = null;
         if (loginForm.getEmail()!=null) {
@@ -111,7 +111,7 @@ public class UserServiceImpl implements UserService {
             updateUserToken(jwt, loginForm.getEmail());
             jwtResponse.setToken(jwt);
         }else {
-            jwtResponse.setMessage(UserMessage.INVALID_CREDENTIALS);
+            jwtResponse.setMessage(UserMessage.INTERNAL_SERVER_ERROR);
         }
 
         return jwtResponse;


### PR DESCRIPTION
## Description
Pull request to fix #55. An incorrect login attempt will now result in a response of `401`.

### Testing
Tested with incorrect email ID and an incorrect password and verified the return status code.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required in the [docs](docs). 
