### PR TITLE
Fix all login inputs to 100 chars

### DIFF
--- a/services/identity/src/main/java/com/crapi/model/ForgetPassword.java
+++ b/services/identity/src/main/java/com/crapi/model/ForgetPassword.java
@@ -24,7 +24,7 @@ import lombok.Data;
 public class ForgetPassword implements Serializable {
 
   @NotBlank
-  @Size(min = 3, max = 60)
+  @Size(min = 3, max = 100)
   @Email
   private String email;
 }

--- a/services/identity/src/main/java/com/crapi/model/LoginForm.java
+++ b/services/identity/src/main/java/com/crapi/model/LoginForm.java
@@ -22,11 +22,11 @@ import lombok.Data;
 public class LoginForm {
 
   @NotBlank
-  @Size(min = 3, max = 60)
+  @Size(min = 3, max = 100)
   private String email;
 
   @NotBlank
-  @Size(min = 4, max = 40)
+  @Size(min = 4, max = 100)
   private String password;
 
   private String number;

--- a/services/identity/src/main/java/com/crapi/model/LoginWithEmailToken.java
+++ b/services/identity/src/main/java/com/crapi/model/LoginWithEmailToken.java
@@ -22,10 +22,10 @@ import lombok.Data;
 public class LoginWithEmailToken {
 
   @NotBlank
-  @Size(min = 3, max = 60)
+  @Size(min = 3, max = 100)
   private String email;
 
   @NotBlank
-  @Size(min = 3, max = 60)
+  @Size(min = 3, max = 100)
   private String token;
 }

--- a/services/identity/src/main/java/com/crapi/model/SignUpForm.java
+++ b/services/identity/src/main/java/com/crapi/model/SignUpForm.java
@@ -24,15 +24,15 @@ public class SignUpForm {
   private Long id;
 
   @NotBlank
-  @Size(min = 3, max = 40)
+  @Size(min = 3, max = 100)
   private String name;
 
   @NotBlank
-  @Size(min = 6, max = 40)
+  @Size(min = 6, max = 100)
   private String password;
 
   @NotBlank
-  @Size(max = 60)
+  @Size(max = 100)
   @Email
   private String email;
 


### PR DESCRIPTION
## Description
Passphrases are becoming stands and we like to allow users to set emails and passwords upto 100 chars in length.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR adds support for OAuth session tampering vulnerability.
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for video uploads to reduce memory usage.
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid race condition.
-->

### Testing
Tests

### Documentation
Make sure that you have documented corresponding changes in this repository. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required in the [docs](docs). 
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
