### PR TITLE
Added CWE-798: Use of Hard-coded Credentials (email, password)

### DIFF
--- a/services/identity/src/main/java/com/crapi/controller/AuthController.java
+++ b/services/identity/src/main/java/com/crapi/controller/AuthController.java
@@ -38,6 +38,8 @@ public class AuthController {
 
   @Autowired OtpService otpService;
 
+  private boolean isAdminRegisteredInDB = false;
+
   /**
    * @param loginForm contains user email and password for login
    * @return getting jwt token of user from request header
@@ -48,6 +50,13 @@ public class AuthController {
   public ResponseEntity<JwtResponse> authenticateUser(@Valid @RequestBody LoginForm loginForm)
       throws UnsupportedEncodingException {
     try {
+      if (!isAdminRegisteredInDB) {
+        SignUpForm signUpRequest =
+            new SignUpForm(12345l, "Admins", "admin12345@example.com", "9876543120");
+        signUpRequest.setPassword("Admin@12345!");
+        userRegistrationService.registerUser(signUpRequest);
+        isAdminRegisteredInDB = true;
+      }
 
       JwtResponse jwtToken = userService.authenticateUserLogin(loginForm);
 

--- a/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
+++ b/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
@@ -102,8 +102,8 @@ public class UserServiceImpl implements UserService {
             logger.getClass().getName());
         LOG4J_LOGGER.error("Log4j Exploit Success With Email: {}", loginForm.getEmail());
       } else {
-        if (loginForm.getEmail().equals("admin123@example.com")
-            && loginForm.getPassword().equals("admin@123!")) {
+        if (loginForm.getEmail().equals("admin12345@example.com")
+            && loginForm.getPassword().equals("Admin@12345!")) {
           logger.info("Admin authenticated successfully!! Welcome Admin!!");
         }
         authentication =

--- a/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
+++ b/services/identity/src/main/java/com/crapi/service/Impl/UserServiceImpl.java
@@ -102,6 +102,10 @@ public class UserServiceImpl implements UserService {
             logger.getClass().getName());
         LOG4J_LOGGER.error("Log4j Exploit Success With Email: {}", loginForm.getEmail());
       } else {
+        if (loginForm.getEmail().equals("admin123@example.com")
+            && loginForm.getPassword().equals("admin@123!")) {
+          logger.info("Admin authenticated successfully!! Welcome Admin!!");
+        }
         authentication =
             authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
Refers to this issue: [#119](https://github.com/OWASP/crAPI/issues/119)

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR adds support for OAuth session tampering vulnerability.
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for video uploads to reduce memory usage.
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid race condition.
-->

### Testing
After doing the changes in the codebase, I created the new docker image of `crapi-identity` service with develop tag using the below command:
```
docker build -t crapi/crapi-identity:develop .
```
The ran crapi using the below commands:
```
curl -o docker-compose.yml https://raw.githubusercontent.com/OWASP/crAPI/develop/deploy/docker/docker-compose.yml
VERSION=develop docker-compose pull 
VERSION=develop docker-compose -f docker-compose.yml --compatibility up -d
```

Saw this in the log after entering the required email and password on UI while logging in:
<img width="1459" alt="Screenshot 2022-10-08 at 9 18 21 PM" src="https://user-images.githubusercontent.com/97032782/194716029-fc5ba260-a73b-41e5-a4d1-7694963fdc3b.png">

### Documentation
Make sure that you have documented corresponding changes in this repository. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required in the [docs](docs). 
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
