### PR TITLE
Update build-image.sh

### DIFF
--- a/services/identity/build-image.sh
+++ b/services/identity/build-image.sh
@@ -15,7 +15,7 @@
 
 set -x
 cd "$(dirname $0)"
-docker build -t crapi/crapi-identity:${VERSION:-latest} .
+docker build --build-arg SERVER_PORT=8181 -t crapi/crapi-identity:${VERSION:-latest} .
 retVal=$?
 if [ $retVal -ne 0 ]; then
     echo "Error building crapi-identity image"


### PR DESCRIPTION
Test msj WARN: 

Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg. WARN[0000] missing "SERVER_PORT" build argument. Try adding "--build-arg SERVER_PORT=<VALUE>" to the command line

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR adds support for OAuth session tampering vulnerability.
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for video uploads to reduce memory usage.
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid race condition.
-->

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested the service locally. 

### Documentation
Make sure that you have documented corresponding changes in this repository. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged
- [ ] I have documented any changes if required in the [docs](docs). 
<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
