### PR TITLE
Enfore auth for receive_report

### DIFF
--- a/services/workshop/crapi/mechanic/views.py
+++ b/services/workshop/crapi/mechanic/views.py
@@ -118,6 +118,7 @@ class ReceiveReportView(APIView):
     """
     View to receive report from contact mechanic feature
     """
+    @jwt_auth_required
     def get(self, request):
         """
         receive_report endpoint for mechanic


### PR DESCRIPTION
## Description
Enfore missing authentication for receive_report

### Testing
CI

### Documentation
Make sure that you have documented corresponding changes in this repository. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged
- [x] I have documented any changes if required in the [docs](docs). 
