### PR TITLE
Fix Docker Build Failure for CRAPI Workshop

### DIFF
--- a/services/workshop/Dockerfile
+++ b/services/workshop/Dockerfile
@@ -24,7 +24,9 @@ RUN apk add --update --no-cache --virtual .build-deps \
         libffi-dev gcc py3-pip \
         python3-dev \
         musl-dev \
-        libffi-dev
+        libffi-dev \
+        cairo-dev \
+        pkgconfig
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -36,7 +38,7 @@ RUN pip install wheel && pip wheel . --wheel-dir /app/wheels
 FROM python:3.11-alpine
 COPY --from=build /app /app
 WORKDIR /app
-RUN apk update && apk add --no-cache postgresql-libs curl
+RUN apk update && apk add --no-cache postgresql-libs curl cairo
 RUN pip install --no-index --find-links=/app/wheels -r requirements.txt
 COPY ./certs /app/certs
 COPY health.sh /app/health.sh


### PR DESCRIPTION
The workshop service Docker build was failing when trying to install pycairo because the Cairo graphics library was missing from the Alpine Linux base image.
