### PR TITLE
added missing env vars

### DIFF
--- a/deploy/k8s/base/identity/config.yaml
+++ b/deploy/k8s/base/identity/config.yaml
@@ -26,3 +26,5 @@ data:
   JWT_EXPIRATION: "604800000"
   SMTP_STARTTLS: "true"
   SERVER_PORT: "8080"
+  TLS_ENABLED: "false"
+  API_GATEWAY_URL: "https://api.mypremiumdealership.com"

--- a/deploy/k8s/base/web/configmap.yaml
+++ b/deploy/k8s/base/web/configmap.yaml
@@ -9,3 +9,4 @@ data:
   IDENTITY_SERVICE: crapi-identity:8080
   WORKSHOP_SERVICE: crapi-workshop:8000
   CHATBOT_SERVICE: crapi-chatbot:5002
+  MAILHOG_WEB_SERVICE: mailhog-web:8025

--- a/deploy/k8s/base/workshop/config.yaml
+++ b/deploy/k8s/base/workshop/config.yaml
@@ -18,3 +18,4 @@ data:
     MONGO_DB_PASSWORD: crapisecretpassword
     MONGO_DB_NAME: crapi
     SERVER_PORT: "8000"
+    API_GATEWAY_URL: "https://api.mypremiumdealership.com"


### PR DESCRIPTION
## Description
Added missing env vars that were preventing several pods from starting. I used k8s deployment on AKS, no Helm chart. Only with these changes the pods were starting.

### Testing
Without these changes, the 3 pods were failing due to unresolved references
