### PR TITLE
Cluster deployments with helm charts with different name space other than "crapi" fails #361

### DIFF
--- a/deploy/helm/templates/rbac/role.yaml
+++ b/deploy/helm/templates/rbac/role.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: crapi
+  namespace: {{ .Release.Namespace }}
   name: waitfor-reader
 rules:
 - apiGroups: [""]

--- a/deploy/helm/templates/rbac/rolebinding.yaml
+++ b/deploy/helm/templates/rbac/rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  namespace: crapi
+  namespace: {{ .Release.Namespace }}
   name: waitfor-grant
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: crapi
+  namespace: {{ .Release.Namespace }}
   apiGroup: ""
 roleRef:
   kind: ClusterRole

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -239,7 +239,7 @@ mailhog:
   replicaCount: 1
   minReadySeconds: 10
   progressDeadlineSeconds: 600
-  namespace: crapi
+  namespace: {{ .Release.Namespace }}
   smtpService:
     name: mailhog
     labels:


### PR DESCRIPTION

## Description
Please include a summary of the change, motivation and context.

 **on a bugfix**:  This change intends to fix issue #361 

Due to hardcoded namespace values, crAPI deployments to clusters were not working when the namespce is other than "crAPI". Helm charts should never have hardcoded values. This is a simple fix that is tested locally.

### Testing
In place of hardcoded values for the namespace, the namespace is dynamically specified based on the helm install. 

Hardcoded "crapi" for namespace was replaced with {{ .Release.Namespace }}

This was tested by deploying crAPI using Helm onto an EKS cluster.

### Checklist:
Only three files are changed: role.yaml, rolebindings.yaml and values.yaml.

